### PR TITLE
[#42]유저와 상대방 프로필 클릭시, 프로필 컴포넌트 재사용

### DIFF
--- a/src/component/Home.jsx
+++ b/src/component/Home.jsx
@@ -11,7 +11,7 @@ const Home = () => {
     const auth = useRecoilValue(authState)
     
     useEffect(()=>{
-        getArticles()
+        getArticles('Gerome')
         .then(res=>{
             setArticleData(res.data.articles)
         }).catch(err=>{

--- a/src/component/Navbar.jsx
+++ b/src/component/Navbar.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useRecoilState } from "recoil";
 import { authState, userState } from '../atoms/auth'
+import { getProfile } from "../remote/index";
+import { profileState } from "../atoms/auth";
+import { useNavigate } from "react-router-dom";
 // <li> 테그에 있는 데이터들을 배열로 이동 시킨후, map 내장함수를 이용해서 뿌려준다
 // 로그인 했을떄랑 안했을때 보여지는게 다른데 그 부분을 배열로 표현 할 수 있는지.
 
@@ -21,6 +24,19 @@ const Navbar = () => {
 
   const auth = useRecoilValue(authState)
   const user = useRecoilValue(userState)  
+  const [profile,setProfile] = useRecoilState(profileState)
+  const navigate = useNavigate()
+
+  const spaceProfile = () =>{
+    getProfile(user.username)
+    .then((res)=>{
+        setProfile(res.data.profile)
+        navigate('/a')
+    }).catch((err)=>{
+        console.log(err)
+     })
+  }
+    
 
   
   return (
@@ -47,9 +63,9 @@ const Navbar = () => {
               </Link>
               </li>
               <li className="nav-item">
-                  <Link className="nav-link active" to='/a'>
+                  <div className="nav-link active" onClick={spaceProfile} style={{cursor:'pointer'}}>
                       {user.username}
-                  </Link>
+                  </div>
               </li>
             </div>
           ) : (

--- a/src/component/Profile.jsx
+++ b/src/component/Profile.jsx
@@ -1,22 +1,29 @@
-import React, { useEffect } from 'react'
+import React, { useEffect,useState } from 'react'
 import { useRecoilState,useRecoilValue } from 'recoil'
 import { profileState,userState } from '../atoms/auth'
 import { getProfile } from '../remote'
-import Article from './ArticleList'
+import { getArticles } from '../remote/index'
+import ArticleList from './ArticleList'
+
 
 const Profile = () => {
+
+    const profile = useRecoilValue(profileState)
+    let [articleData,setArticleData] = useState([])
     
-    const [profile,setProfile] = useRecoilState(profileState)
-    const user = useRecoilValue(userState)
-  
     useEffect(()=>{
-        getProfile(user.username)
-        .then((res)=>{
-            setProfile(res.data.profile)
-        }).catch((err)=>{
-            console.log(err)
-         })
+       getArticles(profile.username)
+       .then(res=>{
+        setArticleData(res.data.articles)
+        
+       }).catch(err=>
+        console.log(err))
+       
+       
+        // get을 호출 파라미터로 들어가는게 위에서는 user(나자신이름), or 상대방 이미지 눌렀을때 이름을 전달하는것, api주소
+        // ->article for profile 밑에 뿌려준다.
     },[])
+   
   
     return (
     <div className="profile-page">
@@ -56,13 +63,10 @@ const Profile = () => {
                         </li>
                     </ul>
                 </div>
-
-                <Article />
-                <Article />
-
                 
-
-
+                {articleData.map((data)=><ArticleList data={data}/>)} 
+                {/* 이 부분은 선택한(클릭시), 유저나 상대방이미지 및 이름을 눌렀을때, 거기에 대한 Article */}
+            
             </div>
 
         </div>

--- a/src/component/WritterInfo.jsx
+++ b/src/component/WritterInfo.jsx
@@ -1,14 +1,35 @@
 import React from "react";
+import { useRecoilState } from "recoil";
+import { profileState } from "../atoms/auth";
+import { useNavigate } from "react-router-dom";
+import { getProfile } from "../remote/index";
+
+
 
 const WritterInfo = ({data}) => {
+  
+  const [profile,setProfile] = useRecoilState(profileState)
+  const navigate = useNavigate()
+
+  const spaceProfile = () =>{
+    getProfile(data.author.username)
+    .then((res)=>{
+        setProfile(res.data.profile)
+        navigate('/a')
+    }).catch((err)=>{
+        console.log(err)
+     })
+  }
+    
+ 
   return (
     
       <div style={{'display':'inline'}}>
-          <a href="">
+          <a onClick={spaceProfile} style={{cursor:'pointer'}}>
             <img src={data.author.image} />
           </a>
           <div className="info">
-            <a href="" className="author">
+            <a onClick={spaceProfile} className="author" style={{cursor:'pointer'}}>
               {data.author.username}
             </a>
             <span className="date">{data.createdAt}</span>

--- a/src/remote/index.jsx
+++ b/src/remote/index.jsx
@@ -118,5 +118,5 @@ const postRegisterUser=(user)=>conduitAxios.post('/users',{user});
 }}
    */
 
-const getArticles = () => conduitAxios.get('/articles')
+const getArticles = (author) => conduitAxios.get(`/articles/?author=${author}&limit=20&offset=0`)
   export {postRegisterUser,postLoginUser,getLoginUser,putLoginUser,getProfile,getArticles};


### PR DESCRIPTION
#42 프로필 컴포넌트를 재사용하기 위해 유저와 상대방의 프로필에 이벤트 각각 사용

- navbar에 출력되는 username을 누르면 user정보를 담은 프로필 컴포넌트 이동
- home 컴포넌트에서 상대방 이미지 또는 이름을 누르면 상대방의 정보를 담은 프로필 컴포넌트로 이동
- api 호출을 각각 클릭시, 따로 주고 이름 정보를 담은 데이터를 recoil에 업데이트 후, 프로필 컴포넌트에서 재사용
- 클릭시마다 recoil정보가 업데이트 되면서 프로필 컴포넌트에서 보여지는 ui가 달라짐.