### PR TITLE
[#46]new article 생성후, 상세페이지 컴포넌트로 이동

### DIFF
--- a/src/atoms/auth.jsx
+++ b/src/atoms/auth.jsx
@@ -28,6 +28,11 @@ export const profileState = atom({
   }
 })
 
+export const slugState = atom({
+  key:'src/atoms/auth.jsx-slugState',
+  default:''
+})
+
 // export const newArticleState = atom({
 //   key: 'src/atoms/auth.jsx-newArticleState',
 //   default:{

--- a/src/component/Article/ArticleContainer.jsx
+++ b/src/component/Article/ArticleContainer.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import ArticleComment from './ArticleComment'
 import ArticleContents from './ArticleContents'
 
-const ArticleContainer = () => {
+const ArticleContainer = ({data}) => {
   return (
     <div className="container page">
 
-    <ArticleContents />
+    <ArticleContents data={data}/>
     <ArticleComment />
     <hr/>
 

--- a/src/component/Article/ArticleContents.jsx
+++ b/src/component/Article/ArticleContents.jsx
@@ -1,14 +1,13 @@
 import React from 'react'
 
-const ArticleContents = () => {
+const ArticleContents = ({data}) => {
   return (
     <div className="row article-content">
     <div className="col-md-12">
         <p>
-            Web development technologies have evolved at an incredible clip over the past few years.
+            {data&&data.body}
         </p>
-        <h2 id="introducing-ionic">Introducing RealWorld.</h2>
-        <p>It's a great solution for learning how other frameworks work.</p>
+        
     </div>
 </div>
   )

--- a/src/component/Article/ArticleDetail.jsx
+++ b/src/component/Article/ArticleDetail.jsx
@@ -1,13 +1,29 @@
 import React from 'react'
 import ArticleContainer from './ArticleContainer'
 import ArticleTitle from './ArticleTitle'
-
+import { getSlugArticle } from '../../remote/index'
+import { useEffect } from 'react'
+import { useRecoilValue } from 'recoil'
+import { slugState } from '../../atoms/auth'
+import { useState } from 'react'
 
 const ArticleDetail = () => {
+
+  const slug = useRecoilValue(slugState)
+  const [data,setArticleData]=useState()
+
+  useEffect(()=>{
+    getSlugArticle(slug)
+    .then(res=>{
+      setArticleData(res.data.article)
+    })
+  },[])
+
+
   return (
     <div className="article-page">
-      <ArticleTitle />
-      <ArticleContainer />
+      <ArticleTitle data={data}/>
+      <ArticleContainer data={data}/>
     </div>
   )
 }

--- a/src/component/Article/ArticleTitle.jsx
+++ b/src/component/Article/ArticleTitle.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import WritterInfo from "../WritterInfo";
 
-const ArticleTitle = () => {
+const ArticleTitle = ({data}) => {
+
   return (
     <div className="banner">
       <div className="container">
-        <h1>How to build webapps that scale</h1>
+        <h1>{data&&data.title}</h1>
 
         <div className="article-meta">
-          <WritterInfo />
+          <WritterInfo data={data}/>
           <button className="btn btn-sm btn-outline-secondary">
             <i className="ion-plus-round"></i>
             &nbsp; Follow Eric Simons <span className="counter">(10)</span>

--- a/src/component/ArticleList.jsx
+++ b/src/component/ArticleList.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import WritterInfo from './WritterInfo'
 
 const ArticleList = ({data}) => {
+
+  // data.slug를 상태에 업데이트를 시켜서 Api 연결 get slug -> ARTICLE DETAIL 컴포넌트 -> 업데이트된 정보를  뿌려준다.
   return (
 <div className="article-preview">
     <div className="article-meta">

--- a/src/component/Newarticle.jsx
+++ b/src/component/Newarticle.jsx
@@ -3,21 +3,29 @@ import { useState } from 'react'
 import { createArticle } from '../remote/index'
 import { useRecoilValue } from 'recoil'
 import { userState } from '../atoms/auth'
+import { useRecoilState } from 'recoil'
+import { slugState } from '../atoms/auth'
+import { useNavigate } from 'react-router-dom'
 
 const Newarticle = () => {
 
     const user = useRecoilValue(userState)
+    const [slug,setSlug] = useRecoilState(slugState)
+
     const [title,setTitle] = useState('')
     const [description,setDescription] = useState('')
     const [body,setBody] = useState('')
     const [tag,setTag] = useState([''])
+
+    const navigate =useNavigate()
 
     const submitArticle = (e)=>{
         e.preventDefault()
 
         createArticle({title,description,body,tag},{user})
         .then(res=>{
-            console.log(res)
+            setSlug(res.data.article.slug)
+            navigate('/b')
         }).catch(err=>{
             console.log(err)
         })

--- a/src/component/WritterInfo.jsx
+++ b/src/component/WritterInfo.jsx
@@ -26,13 +26,13 @@ const WritterInfo = ({data}) => {
     
       <div style={{'display':'inline'}}>
           <a onClick={spaceProfile} style={{cursor:'pointer'}}>
-            <img src={data.author.image} />
+            <img src={data&&data.author.image} />
           </a>
           <div className="info">
             <a onClick={spaceProfile} className="author" style={{cursor:'pointer'}}>
-              {data.author.username}
+              {data&&data.author.username}
             </a>
-            <span className="date">{data.createdAt}</span>
+            <span className="date">{data&&data.createdAt}</span>
           </div>
       </div>
   );

--- a/src/remote/index.jsx
+++ b/src/remote/index.jsx
@@ -129,9 +129,9 @@ const getArticles = (author) => conduitAxios.get(`/articles/?author=${author}&li
     tagList: [
       string
     ];}
-}} newArticle
+}} article
 
-@returns {{articles:
+@returns {{article:
   {
     slug: string;
 title: string;
@@ -155,4 +155,31 @@ author: {
  */
 
 const createArticle = (article,{user}) => conduitAxios.post('/articles',{article},{headers:{authorization:`Bearer ${user.token}`}})
-  export {postRegisterUser,postLoginUser,getLoginUser,putLoginUser,getProfile,getArticles,createArticle};
+
+/**
+ @param {string} slug
+ @returns {{article:
+  {
+    slug: string;
+title: string;
+description: string;
+body: string;
+tagList: [
+  string
+];
+createdAt: 2022-09-11T06:38:57.899Z;
+updatedAt: 2022-09-11T06:38:57.899Z;
+favorited: true;
+favoritesCount: 0;
+author: {
+  username: string;
+  bio: string;
+  image: string;
+  following: true;
+    }
+  }
+}}
+ */
+const getSlugArticle = (slug) => conduitAxios.get(`/articles/${slug}`)
+
+  export {postRegisterUser,postLoginUser,getLoginUser,putLoginUser,getProfile,getArticles,createArticle,getSlugArticle};


### PR DESCRIPTION
#46 Article 상세페이지 컴포넌트로 이동 
 
- create article에서 작성한 데이터를 가지고 Article 상세페이지 컴포넌트로 이동 
- get메소드로 slug를 path에 붙여서 해당되는 article정보를 가져온다.

## 추가해야할 내용
- 홈 컴포넌트에서 상대방 article눌렀을때, 상대방 article 상세페이지로 이동
- article 컴포넌트 안에 comment 부분 미완성