### PR TITLE
[#49] 홈에서 다른사람의 article을 눌렀을떄 이동 및 태그와 팔로우수 수정

### DIFF
--- a/src/component/Article/ArticleContents.jsx
+++ b/src/component/Article/ArticleContents.jsx
@@ -7,7 +7,14 @@ const ArticleContents = ({data}) => {
         <p>
             {data&&data.body}
         </p>
-        
+        <div className="tag-list">
+               {data.tagList.map((data)=>
+                <p className="tag-pill tag-default">{data}</p>
+               )}
+        </div>
+
+
+
     </div>
 </div>
   )

--- a/src/component/Article/ArticleTitle.jsx
+++ b/src/component/Article/ArticleTitle.jsx
@@ -3,6 +3,7 @@ import WritterInfo from "../WritterInfo";
 
 const ArticleTitle = ({data}) => {
 
+  console.log(data)
   return (
     <div className="banner">
       <div className="container">
@@ -12,12 +13,12 @@ const ArticleTitle = ({data}) => {
           <WritterInfo data={data}/>
           <button className="btn btn-sm btn-outline-secondary">
             <i className="ion-plus-round"></i>
-            &nbsp; Follow Eric Simons <span className="counter">(10)</span>
+            &nbsp; Follow {data.author.username} 
           </button>
           &nbsp;&nbsp;
           <button className="btn btn-sm btn-outline-primary">
             <i className="ion-heart"></i>
-            &nbsp; Favorite Post <span className="counter">(29)</span>
+            &nbsp; Favorite Post <span className="counter">({data.favoritesCount})</span>
           </button>
         </div>
       </div>

--- a/src/component/ArticleList.jsx
+++ b/src/component/ArticleList.jsx
@@ -1,7 +1,17 @@
 import React from 'react'
+import { useRecoilState } from 'recoil'
+import { useNavigate } from 'react-router-dom'
+import { slugState } from '../atoms/auth'
 import WritterInfo from './WritterInfo'
 
 const ArticleList = ({data}) => {
+
+  const navigate = useNavigate()
+  const [slug,setSlug] = useRecoilState(slugState)
+  const spaceArticle = () =>{
+    setSlug(data.slug)
+    navigate('/b')
+  }
 
   // data.slug를 상태에 업데이트를 시켜서 Api 연결 get slug -> ARTICLE DETAIL 컴포넌트 -> 업데이트된 정보를  뿌려준다.
   return (
@@ -12,11 +22,11 @@ const ArticleList = ({data}) => {
                     <i className="ion-heart"></i> 
             </button> 
     </div>
-    <a href="" className="preview-link">
+    <div onClick={spaceArticle} className="preview-link">
         <h1>{data.title}</h1>
         <p>{data.description}</p>
         <span>Read more...</span>
-    </a>
+    </div>
 </div>
   )
 }

--- a/src/component/Populartags.jsx
+++ b/src/component/Populartags.jsx
@@ -11,8 +11,6 @@ const Populartags = ({tags}) => {
                {tags.map((tagsData)=>
                <a href="" className="tag-pill tag-default">{tagsData}</a>
                )}
-                
-                
             </div>
         </div>
     </div>


### PR DESCRIPTION
#49 홈 컴포넌트에서 상대방 article눌렀을때, 상대방 article 상세페이지로 이동 
 
- 홈 컴포넌트에서 상대방 article눌렀을때(제목, 부제목, Read more), 상대방 article 상세페이지로 이동 가능
- article content 컴포넌트에 태그정보도 출력 (css는 홈 컴포넌트에 tagList를 copy함)
팔로우 버튼에 작성자와 이름을 일치, favorite article의 숫자를 가져옴.