### PR TITLE
[#57][#58] localStorage를 추가하여 token&slug 사용, header의 토큰 값에 따른 api요청 분할

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,11 +10,29 @@ import Newarticle from './component/Newarticle';
 import Profile from './component/Profile';
 import ArticleDetail from './component/Article/ArticleDetail';
 import {useRecoilState} from 'recoil'
-import {authState} from './atoms/auth'
+import {authState,userState} from './atoms/auth'
+import { useEffect } from 'react';
+import { getLoginUser } from './remote/index';
 
 function App() {
 
   const [auth,setAuth] = useRecoilState(authState)
+  const [user,setUserState] = useRecoilState(userState)
+
+  useEffect(()=>{
+    if(localStorage.getItem('token')){
+      getLoginUser()
+      .then(res=>{
+        setUserState(res.data.user)
+        setAuth(true)
+      }).catch(err=>{
+        console.log(err)
+      })
+      
+    }else{
+      setAuth(false)
+    }
+  },[])
   
   return (
     <div>

--- a/src/component/Article/ArticleDetail.jsx
+++ b/src/component/Article/ArticleDetail.jsx
@@ -11,9 +11,10 @@ const ArticleDetail = () => {
 
   const slug = useRecoilValue(slugState)
   const [data,setArticleData]=useState()
+  
 
   useEffect(()=>{
-    getSlugArticle(slug)
+    getSlugArticle(localStorage.getItem('slug'))
     .then(res=>{
       setArticleData(res.data.article)
     })

--- a/src/component/ArticleList.jsx
+++ b/src/component/ArticleList.jsx
@@ -9,6 +9,7 @@ const ArticleList = ({data}) => {
   const navigate = useNavigate()
   const [slug,setSlug] = useRecoilState(slugState)
   const spaceArticle = () =>{
+    localStorage.setItem('slug',data.slug)
     setSlug(data.slug)
     navigate('/b')
   }

--- a/src/component/Home.jsx
+++ b/src/component/Home.jsx
@@ -4,7 +4,7 @@ import Populartags from './Populartags'
 import { useRecoilValue } from 'recoil'
 import { authState, userState } from '../atoms/auth'
 import { useEffect,useState } from 'react'
-import { getArticles } from '../remote/index'
+import { getGlobalArticles,getGlobalLoginArticles } from '../remote/index'
 
 const Home = () => {
     let [articleData,setArticleData] = useState([])
@@ -12,13 +12,22 @@ const Home = () => {
     const user = useRecoilValue(userState)
     
     useEffect(()=>{
-        getArticles({user})
+        auth?(getGlobalLoginArticles()
         .then(res=>{
             setArticleData(res.data.articles)
         }).catch(err=>{
             console.log(err)
-        })
-    },[])
+        })):
+        (getGlobalArticles()
+        .then(res=>{
+            setArticleData(res.data.articles)
+        }).catch(err=>{
+            console.log(err)
+        }))
+
+    },[auth])
+
+
     const tag = []
     for(let i=0; i<articleData.length; i++){
         for(let k=0; k<articleData[i].tagList.length; k++){

--- a/src/component/Profile.jsx
+++ b/src/component/Profile.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect,useState } from 'react'
 import { useRecoilState,useRecoilValue } from 'recoil'
-import { profileState,userState } from '../atoms/auth'
-import { getProfile } from '../remote'
-import { getArticles } from '../remote/index'
+import { authState, profileState,userState } from '../atoms/auth'
+import { getArticles,getLoginArticles } from '../remote/index'
 import ArticleList from './ArticleList'
 
 
@@ -11,14 +10,23 @@ const Profile = () => {
     const profile = useRecoilValue(profileState)
     const user = useRecoilValue(userState)
     let [articleData,setArticleData] = useState([])
+    const auth = useRecoilValue(authState)
     
     useEffect(()=>{
-       getArticles(profile.username,{user})
+       auth?(getLoginArticles(profile.username)
        .then(res=>{
         setArticleData(res.data.articles)
         
        }).catch(err=>
-        console.log(err))
+        console.log(err)))
+        :
+        (getArticles(profile.username)
+        .then(res=>{
+         setArticleData(res.data.articles)
+         
+        }).catch(err=>
+         console.log(err)))
+        
        
        
         // get을 호출 파라미터로 들어가는게 위에서는 user(나자신이름), or 상대방 이미지 눌렀을때 이름을 전달하는것, api주소

--- a/src/component/Settings.jsx
+++ b/src/component/Settings.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { getLoginUser } from '../remote'
 import { useRecoilState,useSetRecoilState } from 'recoil'
-import { authState, userState } from '../atoms/auth'
+import { authState, userState, profileState } from '../atoms/auth'
 import { useRecoilValue } from 'recoil'
 import { putLoginUser } from '../remote'
 
@@ -14,6 +14,7 @@ const Settings = () => {
     
     const [user,setUser]= useRecoilState(userState)
     const setAuth = useSetRecoilState(authState)
+    const [profile,setProfile] = useRecoilState(profileState)
 
     const [username1,setUsername]=useState(user.username)
     const [useremail,setUserEmail] = useState(user.email)
@@ -22,6 +23,7 @@ const Settings = () => {
 
 
     const logOut = () =>{
+        localStorage.removeItem('token')
         setAuth(false)
         navigate("/")
     }
@@ -34,10 +36,11 @@ const Settings = () => {
         // console.log(user)
 
         putLoginUser({...user,username:username1,email:useremail,bio:biotext})
-        .then(res=>
+        .then(res=>{
             setUser(res.data.user)
-        
-            
+            setProfile(res.data.user)
+            navigate("/a")
+        }
         ).catch(err=>
             console.log(err)
         )

--- a/src/component/Signin.jsx
+++ b/src/component/Signin.jsx
@@ -5,6 +5,7 @@ import { postLoginUser } from '../remote'
 import { authState,userState } from '../atoms/auth'
 import { useRecoilState,useSetRecoilState } from 'recoil'
 
+
 const Signin = () => {
 
     let navigate = useNavigate()
@@ -21,10 +22,11 @@ const Signin = () => {
     
     const handleSubmit = (e)=>{
         e.preventDefault()
-
+        
         postLoginUser({email,password})
         .then((res)=>{
             setUserState(res.data.user)
+            localStorage.setItem("token",res.data.user.token)
             setAuth(true)
             navigate('/')
         }

--- a/src/component/Signup.jsx
+++ b/src/component/Signup.jsx
@@ -22,6 +22,7 @@ const Signup = () => {
         postRegisterUser({username,email,password})
         .then(res=>{
             setUserState(res.data.user)
+            localStorage.setItem("token",res.data.user.token)
             setAuth(true)
             navigate('/')
            

--- a/src/remote/index.jsx
+++ b/src/remote/index.jsx
@@ -50,7 +50,7 @@ const postRegisterUser=(user)=>conduitAxios.post('/users',{user});
     image: string
   }}}
    */
-  const getLoginUser=()=>conduitAxios.get('/user');
+  const getLoginUser=()=>conduitAxios.get('/user',{headers:{authorization:`Bearer ${localStorage.getItem('token')}`}});
   
   
 /**
@@ -92,7 +92,64 @@ const postRegisterUser=(user)=>conduitAxios.post('/users',{user});
 
   //Article
 
+   /**
+   @returns {{articles: [
+    {
+      slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: [
+    string
+  ];
+  createdAt: 2022-09-11T06:38:57.899Z;
+  updatedAt: 2022-09-11T06:38:57.899Z;
+  favorited: true;
+  favoritesCount: 0;
+  author: {
+    username: string;
+    bio: string;
+    image: string;
+    following: true;
+      }
+    }
+  ],
+  articlesCount: 0;
+}}
+   */
+
+const getGlobalArticles = () => conduitAxios.get('/articles?limit=30&offset=0')
+
+
   /**
+   @returns {{articles: [
+    {
+      slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: [
+    string
+  ];
+  createdAt: 2022-09-11T06:38:57.899Z;
+  updatedAt: 2022-09-11T06:38:57.899Z;
+  favorited: true;
+  favoritesCount: 0;
+  author: {
+    username: string;
+    bio: string;
+    image: string;
+    following: true;
+      }
+    }
+  ],
+  articlesCount: 0;
+}}
+   */
+
+const getGlobalLoginArticles = () => conduitAxios.get(`/articles?limit=30&offset=0`,{headers:{authorization:`Bearer ${localStorage.getItem('token')}`}})
+
+/**
    @param {string} author
    @returns {{articles: [
     {
@@ -119,7 +176,36 @@ const postRegisterUser=(user)=>conduitAxios.post('/users',{user});
 }}
    */
 
-const getArticles = ({user}) => conduitAxios.get(`/articles?limit=30&offset=0`,{headers:{authorization:`Bearer ${user.token}`}})
+const getArticles = (author) => conduitAxios.get(`/articles?author=${author}&limit=30&offset=0`)
+
+/**
+   @param {string} author
+   @returns {{articles: [
+    {
+      slug: string;
+  title: string;
+  description: string;
+  body: string;
+  tagList: [
+    string
+  ];
+  createdAt: 2022-09-11T06:38:57.899Z;
+  updatedAt: 2022-09-11T06:38:57.899Z;
+  favorited: true;
+  favoritesCount: 0;
+  author: {
+    username: string;
+    bio: string;
+    image: string;
+    following: true;
+      }
+    }
+  ],
+  articlesCount: 0;
+}}
+   */
+
+const getLoginArticles = (author) => conduitAxios.get(`/articles?author=${author}&limit=30&offset=0`,{headers:{authorization:`Bearer ${localStorage.getItem('token')}`}})
 
 /**
  @param {{article: {
@@ -232,4 +318,4 @@ const getComment = (slug) => conduitAxios.get(`/articles/${slug}/comments`)
 
 const postComment =(slug,comment,{user}) => conduitAxios.post(`/articles/${slug}/comments`,{comment},{headers:{authorization:`Bearer ${user.token}`}})
 
-  export {postRegisterUser,postLoginUser,getLoginUser,putLoginUser,getProfile,getArticles,createArticle,getSlugArticle,getComment,postComment};
+  export {postRegisterUser,postLoginUser,getLoginUser,putLoginUser,getProfile,getGlobalLoginArticles,getGlobalArticles,getArticles,getLoginArticles,createArticle,getSlugArticle,getComment,postComment};


### PR DESCRIPTION
#57 유저의 토큰 값 및 Article에 slug를 localStorage에 저장
#58 로그상태 유무에 따른 Article 출력

1. 로그인,회원가입 했을 때  localStorage를 사용해 토큰값 저장
2.  index.jsx에서 User부분의 Get메소드 활성화, 헤더에 토큰 값 추가한 후, app.jsx에 useEffect를 사용하여 새로고침시 user의 정보를 토큰값을 이용해서 받아옴.
3. home에서 articlelist를 받아올때 (auth로 구별)
    1. 로그인 시 : header에 토큰값 넣어줌 ⇒ global feed에 user의 article도 받아옴
    2. 로그아웃 시 : 토큰값 X ⇒  global feed에 기존 api에 있는 article만 받아옴
4. profile (articleList) 에서 
    1. 로그인 시:  profile 주인의 article만 불러옴  (token O)  파라미터 값으로 author  
    2. 로그아웃 시 : Gerome profile를 누르면 article 불러옴 (token X), 파라미터 값으로 (author)
    
    ⇒ 구별하지 않고 같은 axios를 사용하는 경우 로그아웃 시 header에 토큰값이 없어 오류 발생
5.  article 상세페이지 눌렀을때, article에 대한 데이터들이 내려오면서 slug부분은 localStorage에 저장. (로그인 유무에 관계없이 article 상세페이지에서 새로고침을 누르면 article페이지가 나와야하기 때문에) - localStorage에 저장된 slug를 api 주소로 보낸다.

6.  setting에서 값을 업데이트 했을 때 profile 페이지로 넘어가면서 데이터가 업데이트 된 값으로 바뀜